### PR TITLE
create service accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ target/
 .bloop/
 project/.bloop/
 nginx*
+terraform/.terraform/*
+*.tfstate
+*.tfstate.backup

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,8 @@
+# First time using terraform in this repo
+
+`terraform init`
+
+# Plan and apply terraform
+
+`terraform plan -var-file=<env>.tfvars`
+`terraform apply -var-file=<env>.tfvars`

--- a/terraform/dev.tfvars
+++ b/terraform/dev.tfvars
@@ -1,0 +1,7 @@
+region = "us-central1"
+zone = "us-central1-b"
+env = "dev"
+hamm-cromwell-metadata-notification-creater-service-account-name = "hamm-cromwell-metadata-notification-creater-dev"
+project = "broad-dsde-dev"
+topic-name = "cromwell-metadata-topic-dev"
+metadata-bucket-name = "cromwell-meta-806222273987-sse3sleh0o394cvu0jqk30292o9ecnaq"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,33 @@
+provider "google" {
+  region = "${var.region}"
+}
+
+resource "google_service_account" "hamm-cromwell-metadata-notification-creater" {
+  account_id   = "hamm-notification-creater" # this account id can't be too long
+  display_name = "Service account for hamm cromwell metadata notification creater"
+  project = "${var.project}"
+}
+# Give this service account storage admin role for metadata bucket
+
+resource "google_storage_bucket_iam_binding" "storage-admin" {
+  bucket = "${var.metadata-bucket-name}"
+  role        = "roles/storage.admin"
+
+  members = [
+    "serviceAccount:${google_service_account.hamm-cromwell-metadata-notification-creater.email}",
+  ]
+}
+resource "google_service_account" "hamm-cromwell-metadata-notification-subscriber" {
+  account_id   = "hamm-notification-subscriber" # this account id can't be too long
+  display_name = "Service account for hamm cromwell metadata notification subscriber"
+  project = "${var.project}"
+}
+# Give this service account pubsub admin role
+resource "google_pubsub_topic_iam_binding" "admin" {
+  topic   = "${var.topic-name}"
+  role    = "roles/pubsub.admin"
+  project = "${var.project}"
+  members = [
+    "serviceAccount:${google_service_account.hamm-cromwell-metadata-notification-subscriber.email}",
+  ]
+}

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -1,0 +1,7 @@
+region = "us-central1"
+zone = "us-central1-b"
+env = "prod"
+hamm-cromwell-metadata-notification-creater-service-account-name = "hamm-cromwell-metadata-notification-creater-prod"
+project = "broad-dsde-prod"
+topic-name = "cromwell-metadata-topic-prod"
+metadata-bucket-name = "hamm-cromwell-metadata" #TODO: update this to correct value

--- a/terraform/qiTest.tfvars
+++ b/terraform/qiTest.tfvars
@@ -1,0 +1,7 @@
+region = "us-central1"
+zone = "us-central1-b"
+env = "test"
+hamm-cromwell-metadata-notification-creater-service-account-name = "hamm-cromwell-metadata-notification-creater-qiTest"
+project = "workbench-firestore"
+topic-name = "qi_test"
+metadata-bucket-name = "cromwell_metadata"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,21 @@
+variable "region" {
+  type = "string"
+}
+variable "project" {
+  type = "string"
+}
+variable "zone" {
+  type = "string"
+}
+variable "env" {
+  type = "string"
+}
+variable "hamm-cromwell-metadata-notification-creater-service-account-name" {
+  type = "string"
+}
+variable "topic-name" {
+  type = "string"
+}
+variable "metadata-bucket-name" {
+  type = "string"
+}


### PR DESCRIPTION
This PR uses terraform to
1. Create service account for creating storage notification and give it storage admin role for metadata bucket.
2. Create service account for metadata subscriber, and give it pubsub admin role for metadata topic


I'm running the script manually right now. Even though we don't have terraform pipeline for this set up yet. I think it's better than creating service accounts manually. 
1. It'll be easier to roll out the changes to various google projects/environments
2. It's more visible what the changes are than creating them manually.
3. It'll be easier if later we decide to automate things like this with terraform

I've tested this with workbench-firestore project. If things look good, I'll apply the changes in dsde dev project